### PR TITLE
Small fixes

### DIFF
--- a/config/servspecopt.cfg
+++ b/config/servspecopt.cfg
@@ -408,17 +408,8 @@ DefaultAccessibleRange=18
 
 # EnableWorldMapPackets - 1/0 (default 0)
 #
-<<<<<<< HEAD
 # Custom clients have implemented a packet that tracks the position of party and
 # guild members. This enables the client to overlay member positions on a world
 # map directly inside the client. Set to 1 to enable core handling of this packet.
 #
 EnableWorldMapPackets=0
-=======
-# Custom clients have implemented a packet that tracks the position of party and
-# guild members. This enables the client to overlay member positions on a world
-# map directly inside the client. Set to 1 to enable core handling of this packet.
-#
-EnableWorldMapPackets=0
-
->>>>>>> KikoDev

--- a/pkg/systems/attributes/hooks/vitalInit.src
+++ b/pkg/systems/attributes/hooks/vitalInit.src
@@ -12,7 +12,7 @@ exported function GetHitsRegenRate(unused mobile)
 endfunction
 
 exported function GetHitsMaximumValue(mobile)
-	return GetAttribute(mobile, "Strength") * 100;;
+	return GetAttribute(mobile, "Strength") * 100;
 endfunction
 
 exported function GetManaRegenRate(unused mobile)


### PR DESCRIPTION
Removed double semi-colon from vitalInit.src and fixed an incomplete merge in servspecopt.cfg.